### PR TITLE
Fix SUPABASE_URL for sso container in tests

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -87,9 +87,9 @@ services:
 
   sso:
     environment:
-      # We development and testing, the Auth service needs to contact the users
-      # service directly via Docker vs through the http://localhost domain.
-      - USERS_URL=http://users:7000
+      # In development and testing, the SSO service needs to contact the Supabase
+      # service directly via Docker vs through the http://localhost/v1/supabase domain.
+      - SUPABASE_URL=http://kong:8000
     depends_on:
       - test-web-content
 


### PR DESCRIPTION
Docker's network is really hard to test in development, because you can't use `localhost` to reach other servers (i.e., `localhost` will always mean "this container").  The fix is to override the URL we use in development only for a particular server to use.  Here I'm passing a direct Docker network URL instead.  The sso e2e tests pass for me locally with this change.

I've also removed the `USERS_URL`, which was doing the identical fix, and we don't need anymore.